### PR TITLE
feat: keyboard shortcuts and tempo fixes

### DIFF
--- a/src/python/audio_processor.py
+++ b/src/python/audio_processor.py
@@ -432,6 +432,11 @@ class WavAudioProcessor:
         print(f"Playback tempo updated: {self.playback_tempo_enabled}, "
               f"target={self.target_bpm} BPM, source={self.source_bpm:.2f} BPM")
         
+        # Update audio engine immediately with new tempo settings
+        self.audio_engine.set_playback_tempo(
+            self.playback_tempo_enabled, self.source_bpm, self.target_bpm
+        )
+        
         # Return the new playback ratio for convenience
         return self.get_playback_ratio()
         
@@ -511,6 +516,11 @@ class WavAudioProcessor:
             # Clear segments since they're now invalid
             self.segments = []
             
+            # UPDATE AUDIO ENGINE with new source data
+            self.audio_engine.set_source_audio(
+                self.data_left, self.data_right, self.sample_rate, self.is_stereo
+            )
+            
             # DEBUG: Print detailed information about the result
             print(f"DEBUG: Cut operation result:")
             print(f"DEBUG:   - Old total_time: {old_total_time}, New total_time: {self.total_time}")
@@ -531,6 +541,7 @@ class WavAudioProcessor:
                     print("DEBUG:   - New time is None")
             except TypeError:
                 print("WARNING: TypeError when printing debug info in cut_audio")
+            print(f"DEBUG:   - Audio engine updated with new source data")
             print(f"==== END AUDIO PROCESSOR CUT OPERATION ====\n")
             
             return True


### PR DESCRIPTION
- Add ultra-fast keyboard shortcuts for segment playback (keys 1-9,0,q-p → segments 1-20)
- Fix tempo adjustment synchronization: audio engine now updates immediately when BPM changes
- Fix audio engine sync on cut operations: engine gets updated with new source data
- Fix off-by-one error in segment boundary calculation for keyboard shortcuts
- Improve resampling quality: use kaiser_best instead of kaiser_fast to reduce aliasing
- Fix tempo adjustment for playback: ensure resampling happens for both export and playback

🤖 Generated with [Claude Code](https://claude.ai/code)