### PR TITLE
refactor: remove verbose debug logging and temporarily disable tail fade

### DIFF
--- a/src/python/audio_utils.py
+++ b/src/python/audio_utils.py
@@ -276,8 +276,8 @@ def process_segment_for_output(
             output_sample_rate = sample_rate
     
     # Stage 5: Apply tail fade
-    segment = apply_tail_fade(
-        segment, adjusted_sample_rate, is_stereo, tail_fade_enabled, fade_duration_ms, fade_curve
-    )
+    #segment = apply_tail_fade(
+    #    segment, adjusted_sample_rate, is_stereo, tail_fade_enabled, fade_duration_ms, fade_curve
+    #)
     
     return segment, output_sample_rate


### PR DESCRIPTION
- Remove extensive debug print statements from controller update_view and cut_audio methods
- Comment out tail fade functionality in process_segment_for_output to resolve audio processing issues
- Simplify bounds checking logic while preserving core functionality
- Improve code readability by removing ~100 lines of debug output

🤖 Generated with [Claude Code](https://claude.ai/code)

fixes https://github.com/abrilstudios/rcy/issues/104